### PR TITLE
Rotate logs

### DIFF
--- a/deploytool/utils/commands.py
+++ b/deploytool/utils/commands.py
@@ -9,6 +9,14 @@ def get_folder_size(path):
     return run('du -h --summarize %s' % path)
 
 
+def get_file_size(path):
+    """
+    Returns file size for regular files.
+    Returns -1 if file does not exist or path is not a regular file (e.g. dir or symlink)
+    """
+    return int(run("if [ -f {0} ] && [ ! -h {0} ]; then stat -c %s {0}; else echo '-1'; fi".format(path)))
+
+
 def get_changed_files(local_stamp, remote_stamp, show_full_diff=False):
     """ Returns git diff from remote commit hash vs local HEAD commit hash """
 
@@ -92,6 +100,33 @@ def copy(from_path, to_path):
 def rename(old_path, new_path):
 
     run('mv %s %s' % (old_path, new_path))
+
+
+def rotate_log(log_path, max_bytes=0, backups=0):
+    """
+    Rotates a log file.
+
+    Rotation only happens if the given file path exists, and is >= max_bytes.
+
+    If backups is > 0 log_path will be copied to log_path + .1, previous backups to log_path.n + 1 etc.
+
+    Finally the file in log_path will be truncated.
+    """
+    file_size = get_file_size(log_path)
+    if max_bytes and file_size >= max_bytes:
+        if backups > 0:
+            for i in xrange(backups - 1, 0, -1):
+                source_path = "%s.%d" % (log_path, i)
+                dest_path = "%s.%d" % (log_path, i + 1)
+                if exists(source_path):
+                    if exists(dest_path):
+                        delete(dest_path)
+                    rename(source_path, dest_path)
+            dest_path = log_path + ".1"
+            if exists(dest_path):
+                delete(dest_path)
+            copy(log_path, dest_path)
+        run("> %s" % log_path)
 
 
 def python_run(virtualenv_path, command, sudo_username):

--- a/deploytool/utils/commands.py
+++ b/deploytool/utils/commands.py
@@ -116,17 +116,23 @@ def rotate_log(log_path, max_bytes=0, backups=0):
     if max_bytes and file_size >= max_bytes:
         if backups > 0:
             for i in xrange(backups - 1, 0, -1):
-                source_path = "%s.%d" % (log_path, i)
-                dest_path = "%s.%d" % (log_path, i + 1)
+                if i == 1:
+                    source_path = '%s.1' % log_path
+                    dest_path = '%s.2' % log_path
+                else:
+                    source_path = '%s.%d.gz' % (log_path, i)
+                    dest_path = '%s.%d.gz' % (log_path, i + 1)
                 if exists(source_path):
                     if exists(dest_path):
                         delete(dest_path)
                     rename(source_path, dest_path)
-            dest_path = log_path + ".1"
+                    if i == 1:
+                        run('gzip %s' % dest_path)
+            dest_path = '%s.1' % log_path
             if exists(dest_path):
                 delete(dest_path)
             copy(log_path, dest_path)
-        run("> %s" % log_path)
+        run('> %s' % log_path)
 
 
 def python_run(virtualenv_path, command, sudo_username):

--- a/deploytool/utils/instance.py
+++ b/deploytool/utils/instance.py
@@ -151,6 +151,7 @@ def pip_install_requirements(virtualenv_path, requirements_path, cache_path, log
             '--use-mirrors'
         ]
 
+    commands.rotate_log(log_file, max_bytes=512, backups=10)
     run(' '.join(arguments))
 
 
@@ -242,7 +243,7 @@ def log(success, task_name, stamp, log_path):
         result = 'failed'
 
     message = '[%s] %s %s in %s by %s for %s' % (
-        datetime.today().strftime('%Y-%m-%d %H:%M'),
+        datetime.today().strftime('%Y-%m-%d %H:%M:%S'),
         task_name,
         result,
         env.environment,
@@ -250,4 +251,6 @@ def log(success, task_name, stamp, log_path):
         stamp
     )
 
-    append(os.path.join(log_path, 'fabric.log'), message)
+    log_file = os.path.join(log_path, 'fabric.log')
+    commands.rotate_log(log_file, max_bytes=1024**2, backups=5)
+    append(log_file, message)


### PR DESCRIPTION
Introduces a generic utility command to rotate logs after they reached a certain file size.
Rotate fabric.log when it exceeds 1MB (and keep 5 backups). This should be enough to keep a history of about 50 deploys.
Rotate pip log when it exceeds 512 bytes (and keep 10 backups). This rotates the pip.log after (almost) each run of pip_install_requirements, so you'll get the history of 10 runs.